### PR TITLE
Replace "NASM" with NASM logo

### DIFF
--- a/css/nasm.css
+++ b/css/nasm.css
@@ -76,3 +76,10 @@ p {
 	color: #3b5998;
 	font-weight: bold;
 }
+
+.navbar-home img.navbar-logo {
+    height: 50px; 
+    width: auto; 
+    max-height: 110%; 
+    padding: 5px 10px;
+}

--- a/navbar.inc
+++ b/navbar.inc
@@ -5,14 +5,17 @@ require('./version.inc');
 
 <nav class="navbar navbar-default" role="navigation">
 	<div class="container-fluid container">
+
 		<div class="navbar-header">
-			<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-id">
+    		<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-id">
 				<span class="sr-only">Toggle</span>
 				<span class="icon-bar"></span>
 				<span class="icon-bar"></span>
 				<span class="icon-bar"></span>
 			</button>
-			<a class="navbar-brand" href="index.php">NASM</a>
+    		<a class="navbar-home" href="index.php">
+        		<img src="/images/nasm.png" alt="NASM Logo" class="navbar-logo">
+    		</a>
 		</div>
 
 		<div class="collapse navbar-collapse navbar-right" id="navbar-collapse-id">
@@ -21,10 +24,11 @@ require('./version.inc');
 				<li><a href="https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D">Download</a></li>
 				<li><a href="https://github.com/netwide-assembler/nasm.git">Repo</a></li>
 				<li><a href="docs.php">Docs</a></li>
-				<li><a href="http://bugzilla.nasm.us">Bugs</a></li>
+				<li><a href="https://bugzilla.nasm.us">Bugs</a></li>
 				<li><a href="patches.php">Patches</a></li>
 				<li><a href="https://lists.nasm.us/">Lists</a></li>
 			</ul>
 		</div>
+
 	</div>
 </nav>


### PR DESCRIPTION
Since the logo already includes the text I don't think duplicates are needed.

Previews
======
I would usually host my version but I am working on some updates on my server.

![image](https://github.com/user-attachments/assets/74146361-4dcd-49d8-9d41-c2cc73fa7fa1)

Currently cleaning up a darkmode for the site which I think should just be default rather than all the blinding white.
![image](https://github.com/user-attachments/assets/883c9797-2e60-463b-a031-3789086d89dc)

![image](https://github.com/user-attachments/assets/6c85c55f-1258-4a34-ae6a-f014d3a8a66f)
