### PR TITLE
fix mixed downloads

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -19,7 +19,7 @@
 					following formats: PDF, PostScript, plain text, HTML and info.</p>
 
 					<?php
-					$onl_path = "http://www.$domain/xdoc";
+					$onl_path = "https://www.$domain/xdoc";
 					if ($version) {
 						echo "<h3>Online for NASM $version (stable)</h3>\n";
 						echo "<p><ul>\n";
@@ -37,7 +37,7 @@
 					?>
 
 					<?php
-					$pkg_path = "http://www.$domain/pub/nasm/releasebuilds";
+					$pkg_path = "https://www.$domain/pub/nasm/releasebuilds";
 					if ($version) {
 						$pkg_name = "nasm-$version-xdoc";
 						echo "<h3>Downloadable for NASM $version (stable)</h3>\n";


### PR DESCRIPTION
Mixed downloads will be blocked by browser by default. Change `http` to `https` to fix it.
https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content